### PR TITLE
Fix time formatting when minutes is 1

### DIFF
--- a/utils/TimeUtil.js
+++ b/utils/TimeUtil.js
@@ -66,7 +66,7 @@ export class TimeUtil {
                 .map(
                     ([u, v]) =>
                         `${v} ${
-                            v > 1
+                            v >= 1
                                 ? this.Suffixes[u.toUpperCase()].trim()
                                 : this.Suffixes[u.toUpperCase()].substring(
                                       0,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/38920928/167888295-f4b17fcd-106e-4307-8fe7-7b9f23f576c2.png)

After:
![image](https://user-images.githubusercontent.com/38920928/167888329-3d694485-f426-420a-a173-d09647fd52a3.png)
