### PR TITLE
Fix broken URLs in credits page

### DIFF
--- a/pages/credits.js
+++ b/pages/credits.js
@@ -40,7 +40,10 @@ export default function Home() {
               let license = licenses[pkg]?.licenses
               let repository = licenses[pkg]?.repository
               let url = licenses[pkg]?.url
-
+              if(url && !url.startsWith("http://") && !url.startsWith("https://")){
+                url = `https://${url}`;
+              } 
+              
               return (
                 <tr key={pkgName}>
                   <td>{repository ? <Link href={repository}>{pkgName}</Link> : pkgName}</td>


### PR DESCRIPTION
For example, Sindre Sorhus's URL on the credits page lead to `https://coal.testausserveri.fi/sindresorhus.com`, because it didn't have a protocol specified. This pull request defaults to HTTPS if the URL doesn't have a protocol, and thus leads to the correct page.