### PR TITLE
Update members.status CNAME

### DIFF
--- a/dns/dnsconfig.js
+++ b/dns/dnsconfig.js
@@ -32,7 +32,7 @@ D('testausserveri.fi', REG_NONE, NO_PURGE, DnsProvider(DNS_CLOUDFLARE),
     CNAME('git', 'testausserveri.github.io.'), // GitHub forwarding
     CNAME('static', 'testausserveri.github.io.'), // Static files
     CNAME('status', 'testausserveri.status.protokolla.fi.', CF_PROXY_OFF), // Status webpage
-    CNAME('members.status', 'status.protokolla.fi.', CF_PROXY_OFF), // Status webpage for members
+    CNAME('members.status', 'testausserveri.status.protokolla.fi.', CF_PROXY_OFF), // Status webpage for members
     CNAME('time', 'testausserveri.github.io.'), // TestausTime
     CNAME('ug', 'relay.dfjapis.com.', CF_PROXY_OFF), // TestausTime
     CNAME('openwilma_js', 'openwilma.github.io.'), // OpenWilma js documentation - https://github.com/OpenWilma/


### PR DESCRIPTION
Due to a DNS change https://members.status.testausserveri.fi/ has stopped working. This new CNAME points to the correct server.