### PR TITLE
Improve board person styles

### DIFF
--- a/app/about/about.module.css
+++ b/app/about/about.module.css
@@ -34,8 +34,14 @@
     }
 }
 
-.grid.board span:nth-child(4) {
-    margin-top: -1.5rem;
+.personDetails {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.personTitle {
+    font-size: 0.9rem;
     color: rgba(255,255,255,0.5);
 }
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -137,17 +137,19 @@ export default async function AboutPage() {
                     {([
                         [hanBoardImg, "Mikael Hannolainen", "hallituksen puheenjohtaja"],
                         [sinBoardImg, "Eemil Sinkko", "toiminnanjohtaja, h. vpj, talous"],
-                        [ellBoardImg, "Antti Ellilä", <>tietojärjestelmä-<br />vastaava</>],
+                        [ellBoardImg, "Antti Ellilä", <>tietojärjestelmä&shy;vastaava</>],
                         [serBoardImg, "Sergey Ichtchenko", "yrityssuhdevastaava"],
                         [lepBoardImg, "Aaro Leppänen", "sihteeri"],
-                        [porBoardImg, "Luukas Pörtfors", <>tietojärjestelmä-<br />vastaava</>]
+                        [porBoardImg, "Luukas Pörtfors", <>tietojärjestelmä&shy;vastaava</>]
                     ] as const).map(person => (
                         <div className={styles.personIntroduction} key={person[1]}>
                             <span>
                                 <Image width="64" height="64" src={person[0]} placeholder="blur" alt={person[1]} />
                             </span>
-                            <span>{person[1]}</span><br />
-                            <span>{person[2]}</span>
+                            <div className={styles.personDetails}>
+                                <span>{person[1]}</span>
+                                <span className={styles.personTitle}>{person[2]}</span>
+                            </div>
                         </div>
                     ))}
                 </div>


### PR DESCRIPTION
- Now we only show the hyphen if it's actually needed + when copying the text, it won't include the hyphen when pasting.
- Improved spacing between person name and their title, also made the title font a tiny bit smaller than the name

Before:
<img width="736" height="451" alt="image" src="https://github.com/user-attachments/assets/5807e532-0938-4e08-bc97-9af1af51940e" />

After:
<img width="809" height="463" alt="image" src="https://github.com/user-attachments/assets/b5b018c1-b9b1-4e86-90d7-b03e15b1f049" />

With hyphens:
<img width="728" height="480" alt="image" src="https://github.com/user-attachments/assets/ff9ca2eb-e058-49ed-880a-cc975d292964" />
