### PR TITLE
feat: consolidate social media links

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -18,12 +18,6 @@ import serBoardImg from '@/assets/about/board/ser.jpeg'
 import porBoardImg from '@/assets/about/board/por.jpeg'
 import lepBoardImg from '@/assets/about/board/lep.jpeg'
 
-// icons
-import GithubIcon from '@/assets/GithubIcon.svg'
-import InstagramIcon from '@/assets/InstagramIcon.svg'
-import YoutubeIcon from '@/assets/YoutubeIcon.svg'
-import TwitterIcon from '@/assets/TwitterIcon.svg'
-
 import { GridGallery } from '@/components/GridGallery/GridGallery'
 import { Footer } from '@/components/Footer/Footer'
 import Link from 'next/link'
@@ -32,6 +26,7 @@ import { Collaborations } from '@/components/Collaborations/Collaborations'
 import { NavigateLink } from '@/components/NavigateLink/NavigateLink'
 import api from '@/utils/api'
 import Head from 'next/head'
+import { SOCIAL_MEDIA_LINKS } from '@/utils/constants'
 
 export const revalidate = 600; // 10 minutes
 
@@ -117,15 +112,10 @@ export default async function AboutPage() {
                 <NavigateLink href='/vuosikertomus-2023.pdf'>Vuosikertomus 2023</NavigateLink>
                 <NavigateLink href='/vuosikertomus-2022.pdf'>Vuosikertomus 2022</NavigateLink>
                 <div className={`${styles.grid} ${styles.soc}`}>
-                    {[
-                        ["Instagram", "https://instagram.com/testausserveri", InstagramIcon],
-                        ["Youtube", "https://youtube.com/@testausserveri", YoutubeIcon],
-                        ["Github", "https://github.com/testausserveri", GithubIcon],
-                        ["Twitter", "https://twitter.com/testausserveri", TwitterIcon],
-                    ].map((social) => (
-                        <Link href={social[1]} key={social[0]} className={styles.socialLink}>
-                            <Image src={social[2]} alt={`${social[0]} logo`} height={24} width={24} unoptimized />
-                            {social[0]}
+                    {SOCIAL_MEDIA_LINKS.map((social) => (
+                        <Link href={social.url} key={social.name} className={styles.socialLink}>
+                            <Image src={social.icon} alt={`${social.name} logo`} height={24} width={24} unoptimized />
+                            {social.name}
                         </Link>
                     ))}
                 </div>

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -2,11 +2,10 @@ import { Content } from '../Content/Content'
 import styles from './Footer.module.css'
 import TestausserveriLogo from '../../assets/TestausserveriFullLogo.svg'
 
-import GithubIcon from '../../assets/GithubIcon.svg'
-import InstagramIcon from '../../assets/InstagramIcon.svg'
 import Image from "next/image"
 import Link from 'next/link'
 import { PropsWithChildren } from 'react'
+import { SOCIAL_MEDIA_LINKS } from '@/utils/constants'
 
 const footerLinks = [
     { label: "Tietosuoja", path: "/privacy" },
@@ -14,23 +13,10 @@ const footerLinks = [
     { label: "Yhdistyksen säännöt", path: "/association-rules" },
 ] as const
 
-const socialMedias = [
-    {
-        icon: GithubIcon,
-        name: "GitHub",
-        url: "https://github.com/Testausserveri"
-    },
-    {
-        icon: InstagramIcon,
-        name: "Instagram",
-        url: "https://instagram.com/Testausserveri"
-    }
-] as const
-
 function SocialMedias() {
     return (
         <ul className={`noLinkStyles ${styles.socials}`}>
-            {socialMedias.map(media => (
+            {SOCIAL_MEDIA_LINKS.map(media => (
                 <li key={media.name}>
                     <Link href={media.url}>
                         <Image src={media.icon} alt={`${media.name} logo`} height={24} width={24} unoptimized />

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,27 @@
+import GithubIcon from "@/assets/GithubIcon.svg";
+import InstagramIcon from "@/assets/InstagramIcon.svg";
+import YoutubeIcon from "@/assets/YoutubeIcon.svg";
+import TwitterIcon from "@/assets/TwitterIcon.svg";
+
+export const SOCIAL_MEDIA_LINKS = [
+  {
+    icon: InstagramIcon,
+    name: "Instagram",
+    url: "https://instagram.com/testausserveri",
+  },
+  {
+    icon: YoutubeIcon,
+    name: "Youtube",
+    url: "https://youtube.com/@testausserveri",
+  },
+  {
+    icon: GithubIcon,
+    name: "GitHub",
+    url: "https://github.com/Testausserveri",
+  },
+  {
+    icon: TwitterIcon,
+    name: "Twitter",
+    url: "https://twitter.com/testausserveri",
+  },
+] as const;


### PR DESCRIPTION
Fixes #137 
- Added missing social media accounts to the footer
- No changes on the /about page

Before:
<img width="1208" height="349" alt="image" src="https://github.com/user-attachments/assets/6a16db96-6244-4b8c-8112-1311b359978f" />

After:
<img width="1208" height="349" alt="image" src="https://github.com/user-attachments/assets/e39bd1df-ca47-4e18-afbf-03fca7fbc514" />
