### PR TITLE
Fix profile pictures getting cut off, and align Github icon

### DIFF
--- a/components/AvatarRow/AvatarRow.module.scss
+++ b/components/AvatarRow/AvatarRow.module.scss
@@ -18,7 +18,7 @@
     border-radius: 2rem;
 }
 
-.avatarRow li:not(:nth-last-child(1)) img {
+.avatarRow li:not(:nth-last-child(1)):not(.lastItem) img {
     /* the values are approximated out of the place where sun doesn't shine */
     mask: radial-gradient(circle 20px at 44px center, #0000 98%, #000);
 }

--- a/components/AvatarRow/AvatarRow.tsx
+++ b/components/AvatarRow/AvatarRow.tsx
@@ -7,8 +7,8 @@ import 'react-tooltip/dist/react-tooltip.css'
 import { Member } from '../../utils/types';
 import { getMemberAvatarUrl } from '../../utils/Member';
 import testausorveli from '../../assets/testausorveli.png';
-import Head from 'next/head';
 import { usePlausible } from 'next-plausible';
+import { useCallback, useEffect, useRef } from 'react';
 
 export type AvatarRowProps = {
     members: Member[];
@@ -20,20 +20,49 @@ type AvatarRowPlausibleEvents = {
     hoverAvatar: { hoverAvatarName: string, hoverAvatarId: string }
 }
 
-  
+
 export function AvatarRow({ members, expandOnHover, withNames }: AvatarRowProps) {
     const plausible = usePlausible<AvatarRowPlausibleEvents>();
+    const ref = useRef<HTMLUListElement | null>(null);
+
+    const styleLastItems = useCallback(() => {
+        if (!ref.current) return
+
+        const items = Array.from(ref.current.children);
+
+        items.forEach(item => {
+            item.classList.remove(styles.lastItem);
+        });
+
+        const groups = Object.groupBy(items, x => x.getBoundingClientRect().bottom)
+
+        Object
+            .entries(groups)
+            .map(([_, items]) => items?.at(-1))
+            .filter(last => last != undefined)
+            .forEach((last) => last.classList.add(styles.lastItem))
+    }, []);
+
+    useEffect(() => {
+        styleLastItems()
+
+        window.addEventListener('resize', styleLastItems);
+        return () => {
+            window.removeEventListener("resize", styleLastItems)
+        }
+    }, [styleLastItems])
+
     return (
         <div className={withNames ? styles.withNames : ''}>
             {members.map(member => (
-                <Tooltip 
-                    key={member.name} 
-                    className={styles.tooltip} 
+                <Tooltip
+                    key={member.name}
+                    className={styles.tooltip}
                     id={`avatar-row-tooltip-${member.name}`}>
                     {member.name}
                 </Tooltip>
             ))}
-            <ul className={`${styles.avatarRow} ${expandOnHover ? styles.expandOnHover  : ''}`}>
+            <ul ref={ref} className={`${styles.avatarRow} ${expandOnHover ? styles.expandOnHover  : ''}`}>
                 {members.map(member => {
                     return (
                         <li key={member._id} data-tooltip-id={`avatar-row-tooltip-${member.name}`} onMouseEnter={() => {member.name != "" ? plausible("hoverAvatar", {props: {hoverAvatarName: member.name, hoverAvatarId: member._id.toString()}}) : null}}>

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -127,6 +127,11 @@ const ProjectLinkTitleContainer = styled.div`
   align-items: center;
 `
 
+const ProjectReadmeLinkContainer = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+`
 
 export default function ProjectPage({ projectData: project, mdxSerialized, suggestedProjectsData: suggestedProjects, copyrightYear }: InferGetStaticPropsType<typeof getStaticProps>) {
   const cover = project.media.find(item => item.cover === true)
@@ -164,7 +169,7 @@ export default function ProjectPage({ projectData: project, mdxSerialized, sugge
               </P>
 
               {project.description.full ?
-                <MDXRemote {...mdxSerialized.fullDescription} components={mdxComponents()}/>
+                <MDXRemote {...mdxSerialized.fullDescription} components={mdxComponents()} />
                 : null}
 
               <div style={{ marginTop: "2rem" }}>
@@ -175,10 +180,10 @@ export default function ProjectPage({ projectData: project, mdxSerialized, sugge
                         <span>
                           README.md-dokumentaatio GitHub-repositoriolle
                         </span>
-                        <span>
-                          <FaGithub />
+                        <ProjectReadmeLinkContainer>
+                          <FaGithub style={{ color: "white" }} />
                           <a className="link" href={`https://github.com/${repository}`}>{repository}</a>
-                        </span>
+                        </ProjectReadmeLinkContainer>
                       </span>
                       <MDXRemote {...mdxSerialized.readmes[repository]} />
                     </RepositoryReadme>


### PR DESCRIPTION
Fixed 2 problems:
- Github icon wasn't aligned properly
- Profile pictures were getting cut off if they are the last item on the flex row. Since there is no `:last-flex-row-item` CSS selector, I needed to use JS to detect the last items. Kind of hacky, but works. Now @Trimpsuz cat head is shown properly :)

Before:
<img width="1448" height="888" alt="image" src="https://github.com/user-attachments/assets/7a2de7a6-6e9b-42f2-8a70-6a3f2d1f1853" />

After:
<img width="1650" height="1000" alt="image" src="https://github.com/user-attachments/assets/be5bad49-1823-4079-ae8f-36b600577c44" />
