### PR TITLE
fix: disable blockJS in next-mdx-remote calls

### DIFF
--- a/app/syslog/[slug]/page.tsx
+++ b/app/syslog/[slug]/page.tsx
@@ -85,7 +85,7 @@ async function getPost(slug: string): Promise<Post> {
     console.log("Getting post: ", slug)
     const { content } = await compileMDX<PostDetails>({
         source: raw,
-        options: { parseFrontmatter: true, mdxOptions: {remarkPlugins: [remarkGfm]} },
+        options: { parseFrontmatter: true, blockJS: false, mdxOptions: {remarkPlugins: [remarkGfm]} },
         components: mdxComponents(slug)
       })
     const postDetails = await posts.getPostDetails(`${slug}/post.mdx`);

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -259,6 +259,7 @@ export const getStaticProps: GetStaticProps<{
   const suggestedProjectsData = await api.projects.suggest(data.slug)
 
   const mdxOptions: SerializeOptions = {
+    blockJS: false,
     mdxOptions: {
       format: "md"
     }
@@ -270,7 +271,7 @@ export const getStaticProps: GetStaticProps<{
     readmes[repository] = await serialize(data.readmes[repository], mdxOptions)
   }
 
-  const fullDescription = await serialize(data.description.full)
+  const fullDescription = await serialize(data.description.full, { blockJS: false })
 
   return {
     props:


### PR DESCRIPTION
next-mdx-remote v6 introduced blockJS which defaults to true and strips JS expressions (including JSX attribute expressions like src={[...]} and style={{...}}) from compiled MDX output. This broke post rendering with "Cannot read properties of undefined" errors in components relying on those props. Content is trusted, so opt out; blockDangerousJS stays on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MDX content processing configuration on syslog and project pages to ensure consistent rendering and improve reliability across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->